### PR TITLE
Change turn degrees command to specify charge station 90 degrees

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -101,8 +101,8 @@ public final class Constants {
         public static final double kD                           = 0;
     }
 
-    public static final class kTurnDegrees {
-        public static final double maxAngle                     = 360;
+    public static final class kTurn90DegreesChargeStation {
+        public static final double maxAngle                     = 90;
         public static final double angleTolerance               = 1.5;
 
         public static final double kP_chargeStation             = 0.0125;

--- a/src/main/java/frc/robot/commands/auto/Auto.java
+++ b/src/main/java/frc/robot/commands/auto/Auto.java
@@ -2,6 +2,7 @@ package frc.robot.commands.auto;
 
 import edu.wpi.first.math.trajectory.Trajectory;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import frc.robot.commands.auto.Turn90DegreesChargeStation.TurnDirection;
 import frc.robot.subsystems.Drivetrain;
 
 public class Auto extends SequentialCommandGroup {
@@ -10,7 +11,7 @@ public class Auto extends SequentialCommandGroup {
         super(
             new AutoPathPlanning(sys_drivetrain, trajectory),
             new BalancingChargeStation(sys_drivetrain),
-            new TurnDegrees(sys_drivetrain, -90)
+            new Turn90DegreesChargeStation(sys_drivetrain, TurnDirection.LEFT)
         );
     }
 

--- a/src/main/java/frc/robot/commands/auto/Turn90DegreesChargeStation.java
+++ b/src/main/java/frc/robot/commands/auto/Turn90DegreesChargeStation.java
@@ -5,26 +5,39 @@ import edu.wpi.first.networktables.GenericEntry;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
 import edu.wpi.first.wpilibj2.command.PIDCommand;
-import frc.robot.Constants.kTurnDegrees;
+import frc.robot.Constants.kTurn90DegreesChargeStation;
 import frc.robot.subsystems.Drivetrain;
 
-public class TurnDegrees extends PIDCommand {
+public class Turn90DegreesChargeStation extends PIDCommand {
+
+    public static enum TurnDirection {
+        LEFT, RIGHT
+    }
 
     private final Drivetrain m_drivetrain;
 
-    private static final double kP = kTurnDegrees.kP_chargeStation;
-    private static final double kI = kTurnDegrees.kI_chargeStation;
-    private static final double kD = kTurnDegrees.kD_chargeStation;
+    private static final double kP = kTurn90DegreesChargeStation.kP_chargeStation;
+    private static final double kI = kTurn90DegreesChargeStation.kI_chargeStation;
+    private static final double kD = kTurn90DegreesChargeStation.kD_chargeStation;
 
     // Shuffleboard
     // private final ShuffleboardTab sb_turningTab;
     // private final GenericEntry nt_kP, nt_kI, nt_kD;
 
-    public TurnDegrees(Drivetrain drivetrain, double degrees) {
+    /**
+     * This command should only be used to turn 90 degrees on the charge station.
+     * 
+     * The PID values are tuned for the charge station surface,
+     * and for turning 90 degrees (either direction) specifically.
+     * 
+     * @param drivetrain
+     * @param degrees
+     */
+    public Turn90DegreesChargeStation(Drivetrain drivetrain, TurnDirection direction) {
         super(
             new PIDController(kP, kI, kD),
             drivetrain::getHeading,
-            degrees,
+            (direction == TurnDirection.RIGHT) ? 90 : -90, // turn 90 degrees if right, turn -90 degrees if left
             output -> drivetrain.arcadeDrive(0, output),
             drivetrain
         );
@@ -40,8 +53,8 @@ public class TurnDegrees extends PIDCommand {
         // nt_kI = sb_turningTab.add("kI", 0).getEntry();
         // nt_kD = sb_turningTab.add("kD", 0).getEntry();
 
-        getController().enableContinuousInput(-kTurnDegrees.maxAngle, kTurnDegrees.maxAngle);
-        getController().setTolerance(kTurnDegrees.angleTolerance);
+        getController().enableContinuousInput(-kTurn90DegreesChargeStation.maxAngle, kTurn90DegreesChargeStation.maxAngle);
+        getController().setTolerance(kTurn90DegreesChargeStation.angleTolerance);
     }
 
     // Called when the command is initially scheduled.


### PR DESCRIPTION
The reason for this change is because the PID values are tuned for the charge station surface, and for turning 90 degrees (either direction) specifically.

This change will enforce a 90 degree turn on a charge station.